### PR TITLE
WIP thread jogging

### DIFF
--- a/Teensy_ELS_V2.2.ino
+++ b/Teensy_ELS_V2.2.ino
@@ -102,6 +102,10 @@ volatile bool synced = false;
 int feedSelect = 19;
 int jogRate;
 int jogStepTime = 10;
+// NOTE: if the spindle moves while jogging in a different direction, this may
+// lead to some weird behaviour!
+volatile bool jogMode = false;  // set when starting a jog, lets us know to
+                                // reset the direction back to what it was
 
 // UI Values
 const char gearLetter[3] = {65, 66, 67};
@@ -202,9 +206,9 @@ void loop() {
         leadscrewAngle = 1999;
       }
 
-      if (leadscrewAngleCumulative ==
-          0) {  // disables motor when leadscrew reaches "sync" point
-
+      // disables motor when leadscrew reaches "sync" point
+      if (leadscrewAngleCumulative == 0) {
+        onLeadscrewSync();
         enabled = false;
       }
     }
@@ -220,9 +224,9 @@ void loop() {
         leadscrewAngle = 0;
       }
 
-      if (leadscrewAngleCumulative ==
-          0) {  // disables motor when leadscrew reaches "sync" point
-
+      // disables motor when leadscrew reaches "sync" point
+      if (leadscrewAngleCumulative == 0) {
+        onLeadscrewSync();
         enabled = false;
       }
     }
@@ -443,15 +447,30 @@ void modeCycleCall(
   }
 }
 
+// some logic when leadscrew is synced
+void onLeadscrewSync() {
+  // if we're in jog mode, restore the leadscrew direction
+  if (jogMode == true) {
+    jogMode = false;
+    if (lastDirection == true) {
+      CCW;
+    } else {
+      CW;
+    }
+  }
+}
+
 void jogLeftCall(Button::CALLBACK_EVENT event,
                  uint8_t) {  // jogs left on button hold (one day)
 
   // when in thread mode, a single press should jog one "thread" in the
   // specified direction
   if (event == Button::PRESSED_EVENT) {
-    if (driveMode == true && enabled == false) {
+    if (driveMode == true && enabled == false && jogMode == false) {
+      CW;
       long unsigned int fullThreadRotation = 2000 * numerator / denominator;
       pulseCount -= fullThreadRotation;
+      jogMode = true;
     }
   }
 
@@ -481,9 +500,10 @@ void jogRightCall(Button::CALLBACK_EVENT event,
                   uint8_t) {  /// jogs right on button hold (one day)
 
   if (event == Button::PRESSED_EVENT) {
-    if (driveMode == true) {
+    if (driveMode == true && enabled == false && jogMode == false) {
       long unsigned int fullThreadRotation = 2000 * numerator / denominator;
       pulseCount += fullThreadRotation;
+      jogMode = true;
     }
   }
 


### PR DESCRIPTION
Adds jogging by a multiple of the thread when jogging in thread mode
This (should) back calculate the amount of pulses that it would require to move by one thread, and do it when you press the jog button.

It also has some logic to restore the leadscrew direction when finishing a jog, but it might be a bit weird if the spindle moves while jogging.
(I'll try to explain...)
If we are currently jogging RIGHT, and the spindle moves, it will actually move in the opposite direction, causing the thread to go out of sync. We need to have a separate mode to decrement pulse counts when we're moving opposite to the way we normally move in jog mode. Currently the logic is a bit messy so I don't want to fix this, but it *should* work for simple jogging and allow actual threading without having to reverse the spindle.

