### PR TITLE
Use hardware encoder library for spindle

### DIFF
--- a/lib/spindle/spindle.cpp
+++ b/lib/spindle/spindle.cpp
@@ -4,6 +4,26 @@
 #include <els_elapsedMillis.h>
 #include <math.h>
 
+#ifndef ELS_SPINDLE_DRIVEN
+Spindle::Spindle(int pinA, int pinB) : m_encoder(pinA, pinB) {
+#else
+Spindle::Spindle() {
+#endif
+
+  m_unconsumedPosition = 0;
+  m_lastPulseMicros = 0;
+  m_lastFullPulseDurationMicros = 0;
+  m_currentPosition = 0;
+}
+
+void Spindle::update() {
+  // read the encoder and update the current position
+  // todo: we should keep the absolute position of the spindle, cbf right now
+  int position = m_encoder.read();
+  incrementCurrentPosition(position);
+  m_encoder.write(0);
+}
+
 void Spindle::setCurrentPosition(int position) {
   int newPosition = position % ELS_SPINDLE_ENCODER_PPR;
   m_unconsumedPosition = newPosition - m_currentPosition;

--- a/lib/spindle/spindle.h
+++ b/lib/spindle/spindle.h
@@ -1,3 +1,4 @@
+#include <Encoder.h>
 #include <axis.h>
 #include <els_elapsedMillis.h>
 
@@ -5,11 +6,20 @@
 
 class Spindle : public RotationalAxis {
  private:
- // the unconsumed position is the position that has been read from the encoder
- // but hasn't been used to update the current position of any driven axes
+  // the unconsumed position is the position that has been read from the encoder
+  // but hasn't been used to update the current position of any driven axes
   int m_unconsumedPosition;
 
+#ifndef ELS_SPINDLE_DRIVEN
+  Encoder m_encoder;
+#endif
+
  public:
+#ifndef ELS_SPINDLE_DRIVEN
+  Spindle(int pinA, int pinB);
+#endif
+
+  void update();
   void setCurrentPosition(int position);
   void incrementCurrentPosition(int amount);
   /**


### PR DESCRIPTION
~~Haven't programmed this in yet but should be a drop in replacement~~
Programmed and tested - encoder still works, awwyiss

This uses the encoder library to decode the signals from the encoder. This is provided by PJRC here: https://www.pjrc.com/teensy/td_libs_Encoder.html

No more CPU interrupts to read the encoder so should hopefully be easier to handle 
Afaik it just redirects the interrupts on the pins to the hardware instead of software so we don't need to worry about matrix multiplication anymore as this is all handled for us

Been meaning to do this for a while but Hackaday peeps suggested this instead of reimplementing the entire project using a 555: https://hackaday.com/2024/09/19/lathe-outfitted-with-electronic-gearbox/